### PR TITLE
Fix IncompatibleClassChangeError when hardening Compose apps with --k…

### DIFF
--- a/dpt/src/main/java/com/luoye/dpt/builder/AndroidPackage.java
+++ b/dpt/src/main/java/com/luoye/dpt/builder/AndroidPackage.java
@@ -674,9 +674,9 @@ public abstract class AndroidPackage {
                 }
 
                 if(isKeepClasses() && DexUtils.dexContainsKeepInPlace(dexFile)) {
-                    // 含 Compose 等“原地保留”类的 dex 整体跳过 split：
-                    // 二分重写会破坏 Compose interface 的跨 dex 链接，引发 IncompatibleClassChangeError。
-                    // 该 dex 仍会走 extractAllMethods 抽取（其中匹配规则的类自动跳过），只是不拆分。
+                    // Skip split entirely for dexes containing keep-in-place classes (e.g. Compose):
+                    // the re-partition would break Compose's cross-dex interface linking and cause IncompatibleClassChangeError.
+                    // The dex still goes through extractAllMethods (rule-matched classes are skipped as usual); it is just not split.
                     LogUtils.info("Skip split for dex with keep-in-place classes (e.g. Compose): %s", dexFile.getName());
                 }
                 else if(isKeepClasses()) {

--- a/dpt/src/main/java/com/luoye/dpt/builder/AndroidPackage.java
+++ b/dpt/src/main/java/com/luoye/dpt/builder/AndroidPackage.java
@@ -673,7 +673,13 @@ public abstract class AndroidPackage {
                     injectedDexFile.delete();
                 }
 
-                if(isKeepClasses()) {
+                if(isKeepClasses() && DexUtils.dexContainsKeepInPlace(dexFile)) {
+                    // 含 Compose 等“原地保留”类的 dex 整体跳过 split：
+                    // 二分重写会破坏 Compose interface 的跨 dex 链接，引发 IncompatibleClassChangeError。
+                    // 该 dex 仍会走 extractAllMethods 抽取（其中匹配规则的类自动跳过），只是不拆分。
+                    LogUtils.info("Skip split for dex with keep-in-place classes (e.g. Compose): %s", dexFile.getName());
+                }
+                else if(isKeepClasses()) {
                     File keepDex = new File(getKeepDexTempDir(packageDir).getAbsolutePath() + File.separator + dexFile.getName());
                     File splitDex = new File(dexFile.getAbsolutePath() + "_split.dex");
 

--- a/dpt/src/main/java/com/luoye/dpt/util/DexUtils.java
+++ b/dpt/src/main/java/com/luoye/dpt/util/DexUtils.java
@@ -43,6 +43,48 @@ public class DexUtils {
     private final static Map<String,Integer> codeOffAppearMap = new ConcurrentHashMap<>();
 
     /**
+     * 这些前缀的类必须“原地保留”：开启 -K(keep-classes) 时，它们既不抽取方法体，
+     * 也不能被搬动到独立的 keep dex —— 否则会改变其 dex 归属，破坏 Compose 等框架
+     * 对 interface default 方法的跨 dex 链接，导致启动时 IncompatibleClassChangeError 崩溃。
+     */
+    private static final String[] KEEP_IN_PLACE_PREFIXES = {
+            "Landroidx/compose/",
+    };
+
+    private static boolean keepInPlace(String type) {
+        if (type == null) {
+            return false;
+        }
+        for (String prefix : KEEP_IN_PLACE_PREFIXES) {
+            if (type.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 判断一个 dex 是否包含“原地保留”的类（如 Compose）。
+     * 含有这类类的 dex 必须整体跳过 split：splitDex 的二分重写会改变 dex 的类布局/类型表，
+     * 破坏 Compose interface 的跨 dex 链接，导致运行时 IncompatibleClassChangeError。
+     */
+    public static boolean dexContainsKeepInPlace(File dexFile) {
+        try {
+            DexBackedDexFile dex = DexFileFactory.loadDexFile(dexFile, Opcodes.getDefault());
+            for (com.android.tools.smali.dexlib2.iface.ClassDef classDef : dex.getClasses()) {
+                if (keepInPlace(classDef.getType())) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LogUtils.warn("check keep-in-place failed for %s, will skip split to be safe: %s",
+                    dexFile.getName(), e);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Inject reflection-based JniBridge.clinit calls into eligible static initializers.
      * Helper methods are generated via dexlib2 and spread across different classes.
      */

--- a/dpt/src/main/java/com/luoye/dpt/util/DexUtils.java
+++ b/dpt/src/main/java/com/luoye/dpt/util/DexUtils.java
@@ -43,9 +43,10 @@ public class DexUtils {
     private final static Map<String,Integer> codeOffAppearMap = new ConcurrentHashMap<>();
 
     /**
-     * 这些前缀的类必须“原地保留”：开启 -K(keep-classes) 时，它们既不抽取方法体，
-     * 也不能被搬动到独立的 keep dex —— 否则会改变其 dex 归属，破坏 Compose 等框架
-     * 对 interface default 方法的跨 dex 链接，导致启动时 IncompatibleClassChangeError 崩溃。
+     * Classes with these prefixes must be kept in place: with -K(keep-classes) they are
+     * neither extracted nor moved to a separate keep dex. Moving them would change their
+     * dex membership and break ART's cross-dex linking of interface default methods
+     * (e.g. in Compose), causing IncompatibleClassChangeError at launch.
      */
     private static final String[] KEEP_IN_PLACE_PREFIXES = {
             "Landroidx/compose/",
@@ -64,9 +65,10 @@ public class DexUtils {
     }
 
     /**
-     * 判断一个 dex 是否包含“原地保留”的类（如 Compose）。
-     * 含有这类类的 dex 必须整体跳过 split：splitDex 的二分重写会改变 dex 的类布局/类型表，
-     * 破坏 Compose interface 的跨 dex 链接，导致运行时 IncompatibleClassChangeError。
+     * Returns whether a dex contains "keep-in-place" classes (e.g. Compose).
+     * Such a dex must skip splitting entirely: the re-partition in splitDex rewrites the
+     * dex's class layout / type tables and breaks Compose's cross-dex interface linking,
+     * causing IncompatibleClassChangeError at runtime.
      */
     public static boolean dexContainsKeepInPlace(File dexFile) {
         try {


### PR DESCRIPTION
## Root cause
With `--keep-classes`, `splitDex` re-partitions each dex with dexlib2 (read →
write), splitting classes into a separate "keep" dex and reorganizing the
remaining dex. This changes the dex membership/type tables of Compose classes
and breaks ART's cross-dex linking of interface default-method calls (e.g.
`DrawScope`), causing `IncompatibleClassChangeError`.
Without `-K`, dexes are not re-partitioned (only clinit injection + byte-level
method extraction, both of which preserve class layout), so Compose works fine.
## Fix
Skip splitting entirely for any dex that contains "keep-in-place" classes
(currently `Landroidx/compose/`):
- `DexUtils.dexContainsKeepInPlace(File)` detects such dexes.
- `AndroidPackage.extractDexCode` skips `splitDex` for them; they still go
  through method extraction (matched classes are skipped as before), keeping
  the original class layout intact.
- Dexes without Compose classes are still split, preserving the `-K` startup
  optimization.
The prefix list (`KEEP_IN_PLACE_PREFIXES`) is easy to extend if other
frameworks hit the same issue.